### PR TITLE
Add turbo-rails as a gemspec dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     uni_rails (0.2.2)
       rackup (~> 2.1)
       rails (~> 7.1)
+      turbo-rails (~> 2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -183,6 +184,10 @@ GEM
     stringio (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
+    turbo-rails (2.0.5)
+      actionpack (>= 6.0.0)
+      activejob (>= 6.0.0)
+      railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     webrick (1.8.1)

--- a/examples/todos-hotwire.rb
+++ b/examples/todos-hotwire.rb
@@ -10,12 +10,10 @@ gemfile(true) do
   source "https://rubygems.org"
 
   gem 'uni_rails'
-  gem 'sqlite3'
-  gem 'turbo-rails'
+  gem 'sqlite3', '~> 1.7'
 end
 
 require 'uni_rails'
-require 'turbo-rails'
 require 'sqlite3'
 
 ActiveRecord::Base.establish_connection
@@ -27,18 +25,7 @@ ActiveRecord::Schema.define do
   end
 end
 
-# We currently do not support ActionCable and ActiveJob
-Rails.application.configure do
-  initializer "turbo.no_action_cable", before: :set_eager_load_paths do
-    unless defined?(ActionCable)
-      Rails.autoloaders.once.do_not_eager_load("#{Turbo::Engine.root}/app/channels")
-    end
-
-    unless defined?(ActiveJob)
-      Rails.autoloaders.once.do_not_eager_load("#{Turbo::Engine.root}/app/jobs")
-    end
-  end
-end
+UniRails.enable_turbo_rails!
 
 UniRails::App.routes.append do
   root 'todos#index'
@@ -136,10 +123,6 @@ class TodosController < ActionController::Base
 end
 
 # VIEWS
-
-UniRails.import_maps(
-  "turbo" => "https://unpkg.com/@hotwired/turbo@8.0.4/dist/turbo.es2017-umd.js"
-)
 
 UniRails.javascript <<~JAVASCRIPT
   import * as Turbo from "turbo"

--- a/features/todos-hotwire/Gemfile
+++ b/features/todos-hotwire/Gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gem 'uni_rails', path: '/usr/local/bundle'
 gem "sqlite3", "~> 1.7"
-gem 'turbo-rails'
 
 # Test
 gem "capybara", "~> 3.40"

--- a/features/todos-hotwire/app.rb
+++ b/features/todos-hotwire/app.rb
@@ -1,5 +1,4 @@
 require 'uni_rails'
-require 'turbo-rails'
 require 'debug'
 require 'sqlite3'
 
@@ -12,18 +11,7 @@ ActiveRecord::Schema.define do
   end
 end
 
-# We currently do not support ActionCable and ActiveJob
-Rails.application.configure do
-  initializer "turbo.no_action_cable", before: :set_eager_load_paths do
-    unless defined?(ActionCable)
-      Rails.autoloaders.once.do_not_eager_load("#{Turbo::Engine.root}/app/channels")
-    end
-
-    unless defined?(ActiveJob)
-      Rails.autoloaders.once.do_not_eager_load("#{Turbo::Engine.root}/app/jobs")
-    end
-  end
-end
+UniRails.enable_turbo_rails!
 
 UniRails::App.routes.append do
   root 'todos#index'
@@ -121,10 +109,6 @@ class TodosController < ActionController::Base
 end
 
 # VIEWS
-
-UniRails.import_maps(
-  "turbo" => "https://unpkg.com/@hotwired/turbo@8.0.4/dist/turbo.es2017-umd.js"
-)
 
 UniRails.javascript <<~JAVASCRIPT
   import * as Turbo from "turbo"

--- a/lib/uni_rails.rb
+++ b/lib/uni_rails.rb
@@ -13,6 +13,27 @@ require_relative "uni_rails/app/views"
 module UniRails
   class Error < StandardError; end
 
+  def self.enable_turbo_rails!
+    # # We currently do not support ActionCable and ActiveJob
+    require "turbo-rails"
+
+    App.configure do
+      initializer "turbo.no_action_cable", before: :set_eager_load_paths do
+        unless defined?(ActionCable)
+          Rails.autoloaders.once.do_not_eager_load("#{Turbo::Engine.root}/app/channels")
+        end
+
+        unless defined?(ActiveJob)
+          Rails.autoloaders.once.do_not_eager_load("#{Turbo::Engine.root}/app/jobs")
+        end
+      end
+    end
+
+    UniRails::App::Javascript.dependencies = {
+      "turbo" => "https://unpkg.com/@hotwired/turbo@8.0.4/dist/turbo.es2017-umd.js"
+    }
+  end
+
   def self.rackup_handler=(handler)
     @@rackup_handler = handler
   end

--- a/lib/uni_rails/app/javascript.rb
+++ b/lib/uni_rails/app/javascript.rb
@@ -7,8 +7,12 @@ module UniRails
         instance.imports
       end
 
+      def self.default_dependencies=(dependencies)
+        instance.default_dependencies = dependencies
+      end
+
       def self.dependencies=(dependencies)
-        instance.dependencies = dependencies
+        instance.dependencies = instance.default_dependencies.merge(dependencies)
       end
 
       def self.javascript
@@ -19,8 +23,9 @@ module UniRails
         instance.javascript = content
       end
 
-      attr_accessor :dependencies, :javascript
+      attr_accessor :dependencies, :default_dependencies, :javascript
       def initialize
+        @default_dependencies = {}
         @dependencies = {}
         @javascript = ""
       end

--- a/uni_rails.gemspec
+++ b/uni_rails.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "rails", "~> 7.1"
   spec.add_dependency "rackup", "~> 2.1"
+  spec.add_dependency "turbo-rails", "~> 2.0"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
Fixes #7 

You can now enable TurboRails without knowing about ActiveJob and ActionCable

    UniRails.enable_turbo_rails!